### PR TITLE
Add Email Notification when CRON job fails

### DIFF
--- a/class-gfmomentousfeedaddon.php
+++ b/class-gfmomentousfeedaddon.php
@@ -18,6 +18,8 @@ class GFMomentousFeedAddOn extends GFFeedAddOn
     const MOMENTOUS_CLIENT_SECRET_NAME = 'client_secret';
     const MOMENTOUS_ASYNC_SENDING_NAME = 'async';
     const MOMENTOUS_ASYNC_SENDING_LABEL = 'Enable Asynchronous sending';
+    const MOMENTOUS_FAILED_EMAIL_NOTIFICATION_LABEL = 'Email to receive CRON failure alerts';
+    const MOMENTOUS_FAILED_EMAIL_NOTIFICATION_NAME = 'email_cron_failure_alerts';
     const REQUEST_TABLE = 'momentous_requests';
 
 
@@ -112,6 +114,14 @@ class GFMomentousFeedAddOn extends GFFeedAddOn
                                 "name"  => self::MOMENTOUS_ASYNC_SENDING_NAME,
                             ]
                         ]
+                    ),
+                    array(
+                        'name' => self::MOMENTOUS_FAILED_EMAIL_NOTIFICATION_NAME,
+                        'label' => esc_html__(self::MOMENTOUS_FAILED_EMAIL_NOTIFICATION_LABEL, 'gravityforms-momentous'),
+                        'type' => 'text',
+                        'class' => 'medium',
+                        'required' => true,
+                        'feedback_callback' => array($this, 'plugin_settings_fields_feedback_callback'),
                     ),
                 ),
             ),

--- a/momentousaddon.php
+++ b/momentousaddon.php
@@ -15,6 +15,20 @@ add_action('gform_after_submission', array( 'GF_Momentous_Feed_AddOn_Bootstrap',
 add_action('momentous_async_send_cron', array( 'GF_Momentous_Feed_AddOn_Bootstrap', 'do_async_send' ));
 add_action('momentous_process_failed_requests_cron', array( 'GF_Momentous_Feed_AddOn_Bootstrap', 'process_async_failed_requests' ));
 
+// Register watchdog CRON and its schedule
+add_action('init', function () {
+    if (!wp_next_scheduled('momentous_async_send_cron')) {
+        wp_schedule_event(time(), 'every_one_minute', 'momentous_async_send_cron');
+    }
+    if (!wp_next_scheduled('momentous_process_failed_requests_cron')) {
+        wp_schedule_event(time(), 'every_two_minutes', 'momentous_process_failed_requests_cron');
+    }
+    if (!wp_next_scheduled('momentous_cron_watchdog')) {
+        wp_schedule_event(time(), 'every_ten_minutes', 'momentous_cron_watchdog');
+    }
+});
+add_action('momentous_cron_watchdog', 'momentous_check_cron_health');
+
 add_filter('cron_schedules', array('GF_Momentous_Feed_AddOn_Bootstrap','cron_schedule_filter'));
 
 register_activation_hook(__FILE__, array( 'GF_Momentous_Feed_AddOn_Bootstrap', 'activate_cron' ));
@@ -80,6 +94,9 @@ class GF_Momentous_Feed_AddOn_Bootstrap
         if (!wp_next_scheduled('momentous_process_failed_requests_cron')) {
             wp_schedule_event(time(), 'every_two_minutes', 'momentous_process_failed_requests_cron');
         }
+        if (!wp_next_scheduled('momentous_cron_watchdog')) {
+            wp_schedule_event(time(), 'every_ten_minutes', 'momentous_cron_watchdog');
+        }
     }
 
     public static function deactivate_cron()
@@ -93,15 +110,22 @@ class GF_Momentous_Feed_AddOn_Bootstrap
         if ($timestamp) {
             wp_unschedule_event($timestamp, 'momentous_process_failed_requests_cron');
         }
+
+        $timestamp = wp_next_scheduled('momentous_cron_watchdog');
+        if ($timestamp) {
+            wp_unschedule_event($timestamp, 'momentous_cron_watchdog');
+        }
     }
 
     public static function do_async_send()
     {
+        update_option('momentous_last_async_cron', time());
         $object = gf_momentous_feed_addon();
         $object->process_async_requests();
     }
 
     public static function process_async_failed_requests() {
+        update_option('momentous_last_failed_cron', time());
         $object = gf_momentous_feed_addon();
         $object->process_failed_async_requests();
     }
@@ -114,6 +138,10 @@ class GF_Momentous_Feed_AddOn_Bootstrap
         $schedules['every_one_minute'] = [
             'interval' => 60, // 60 seconds = 1 minute
             'display'  => __('Every minute'),
+        ];
+        $schedules['every_ten_minutes'] = [
+            'interval' => 600,
+            'display'  => __('Every 10 Minutes')
         ];
         return $schedules;
     }
@@ -130,4 +158,35 @@ class GF_Momentous_Feed_AddOn_Bootstrap
 function gf_momentous_feed_addon()
 {
     return GFMomentousFeedAddOn::get_instance();
+}
+
+// Watchdog function (runs every 10 min to check CRON health)
+function momentous_check_cron_health()
+{
+    $async_time  = get_option('momentous_last_async_cron');
+    $failed_time = get_option('momentous_last_failed_cron');
+    $now         = time();
+    $threshold   = 10 * 60; // 10 minutes
+    $problems    = [];
+
+    if (!$async_time || ($now - $async_time) > $threshold) {
+        $problems[] = 'momentous_async_send_cron has not run in the last 10 minutes.';
+    }
+
+    if (!$failed_time || ($now - $failed_time) > $threshold) {
+        $problems[] = 'momentous_process_failed_requests_cron has not run in the last 10 minutes.';
+    }
+
+    if (!empty($problems)) {
+        $message = "<p><strong>Momentous CRON Failure Watchdog Alert</strong></p>";
+        $message .= '<ul><li>' . implode('</li><li>', $problems) . '</li></ul>';
+        $message .= "<p>Time checked: " . current_time('mysql') . "</p>";
+
+        $settings = gf_momentous_feed_addon()->get_plugin_settings();
+        $to = !empty($settings['email_cron_failure_alerts']) ? $settings['email_cron_failure_alerts'] : get_option('admin_email');
+        
+        $subject = 'Momentous CRON Failure Detected';
+
+        wp_mail($to, $subject, $message, ['Content-Type: text/html']);
+    }
 }


### PR DESCRIPTION
This pull request introduces a new feature to the `shakewellagency/momentus-gravity-forms` repository. It adds email notifications for CRON job failures. The changes include the addition of new constants and a settings field in the `class-gfmomentousfeedaddon.php` file to support this functionality. The source branch for these changes is `cron-failure-notification`, and the target branch is `main`.